### PR TITLE
Fixes for Unity 2018

### DIFF
--- a/BitAnimator.cs
+++ b/BitAnimator.cs
@@ -595,7 +595,7 @@ namespace AudioVisualization
                 float[] scaledSpectrumChunk = DSP.Math.Multiply(sampleChunk, windowCoefs);
 
                 // Perform the FFT and convert output (complex numbers) to Magnitude
-                System.Numerics.Complex[] fftSpectrum = fft.Execute(scaledSpectrumChunk);
+                ComplexFloat[] fftSpectrum = fft.Execute(scaledSpectrumChunk);
                 float[] scaledFFTSpectrum = DSP.ConvertComplex.ToMagnitude(fftSpectrum);
                 scaledFFTSpectrum = DSP.Math.Multiply(scaledFFTSpectrum, scaleFactor);
 

--- a/BitAnimator.cs
+++ b/BitAnimator.cs
@@ -12,7 +12,6 @@
 #if UNITY_EDITOR
 using System;
 using System.Collections.Generic;
-using System.Numerics;
 using System.IO;
 using UnityEngine;
 using UnityEditor;
@@ -596,7 +595,7 @@ namespace AudioVisualization
                 float[] scaledSpectrumChunk = DSP.Math.Multiply(sampleChunk, windowCoefs);
 
                 // Perform the FFT and convert output (complex numbers) to Magnitude
-                Complex[] fftSpectrum = fft.Execute(scaledSpectrumChunk);
+                System.Numerics.Complex[] fftSpectrum = fft.Execute(scaledSpectrumChunk);
                 float[] scaledFFTSpectrum = DSP.ConvertComplex.ToMagnitude(fftSpectrum);
                 scaledFFTSpectrum = DSP.Math.Multiply(scaledFFTSpectrum, scaleFactor);
 

--- a/BitAnimator.cs
+++ b/BitAnimator.cs
@@ -145,7 +145,7 @@ namespace AudioVisualization
                 tasks[p].values = new ComputeBuffer(chunks, 4);
                 tasks[p].buffer = new ComputeBuffer(chunks, 4);
                 //Резервируем буффер для ключей XYZW|RGBA
-                tasks[p].keyframes = new ComputeBuffer(chunks * tasks[p].Channels, 20);
+                tasks[p].keyframes = new ComputeBuffer(chunks * tasks[p].Channels, 32);
             }
 
             //разделяем вычисление спектра на блоки
@@ -377,7 +377,7 @@ namespace AudioVisualization
                 tasks[p].values = new ComputeBuffer(chunks, 4);
                 tasks[p].buffer = new ComputeBuffer(chunks, 4);
                 //Резервируем буффер для ключей XYZW|RGBA
-                tasks[p].keyframes = new ComputeBuffer(chunks * tasks[p].Channels, 20);
+                tasks[p].keyframes = new ComputeBuffer(chunks * tasks[p].Channels, 32);
             }
             status = "Calculating spectrum";
             if (updateCallback != null) updateCallback(this);
@@ -791,7 +791,7 @@ namespace AudioVisualization
             }
             public void SetRemapCurve(Vector4 min, Vector4 max, AnimationCurve curve, int mask)
             {
-                remapKeyframes = new ComputeBuffer(curve.length, 20);
+                remapKeyframes = new ComputeBuffer(curve.length, 32);
                 remapKeyframes.SetData(curve.keys);
                 this.min = min;
                 this.max = max;
@@ -818,7 +818,7 @@ namespace AudioVisualization
                     ks[offset + i].time = gradient.alphaKeys[i].time;
                     ks[offset + i].value = gradient.alphaKeys[i].alpha;
                 }
-                gradientKeyframes = new ComputeBuffer(ks.Length, 20);
+                gradientKeyframes = new ComputeBuffer(ks.Length, 32);
                 gradientKeyframes.SetData(ks);
                 min = Vector4.zero;
                 max = Vector4.one;

--- a/BitAnimator.cs
+++ b/BitAnimator.cs
@@ -67,7 +67,7 @@ namespace AudioVisualization
         {
             public enum PropertiesSet
             {
-                Material, ParticleSystem, BlendShape, Transform
+                Material, ParticleSystem, BlendShape, Transform, Attribute
             };
             //Extension for ShaderUtil.ShaderPropertyType
             public enum PropertyType
@@ -316,6 +316,7 @@ namespace AudioVisualization
             switch (set)
             {
                 case RecordSlot.PropertiesSet.Material:
+                case RecordSlot.PropertiesSet.Attribute:
                     return targetObject.GetComponent<Renderer>().GetType();
                 case RecordSlot.PropertiesSet.ParticleSystem:
                     return typeof(ParticleSystem);
@@ -503,7 +504,6 @@ namespace AudioVisualization
                     }
                     else
                         taskProgress += 0.5f / recordSlots.Count / animationProperties.Length;
-
                     curve.keys = keyframes;
                     clip.SetCurve(go_path, renderType, animationProperties[c], curve);
                 }
@@ -769,6 +769,7 @@ namespace AudioVisualization
                 AssetDatabase.Refresh();
             }
         }
+
         public ComputeShader computeShader;
         public RenderTexture computeShaderResult;
         public struct Task

--- a/BitAnimatorEditor.cs
+++ b/BitAnimatorEditor.cs
@@ -238,6 +238,7 @@ public class BitAnimatorEditor : Editor
 			UpdateParticleProperties ();
 			UpdateShaderProperties ();
 			UpdateTransformProperties ();
+            UpdateAttributeProperties();
             availableProperties = availableVariables.Select(x => x.description).ToArray();
             updateList = false;
         }
@@ -502,7 +503,39 @@ public class BitAnimatorEditor : Editor
         }
 	}
 
-	public void UpdateBlendShapeProperties() 
+    public void UpdateAttributeProperties()
+    {
+        var d = new[]{
+            new { name = "Attribute/Enabled", propertyName = "m_Enabled", type = BitAnimator.RecordSlot.PropertyType.Range, rangeMin = 0.0f, rangeMax = 1.0f},
+        };
+
+        foreach (var transformVariable in d)
+        {
+            BitAnimator.RecordSlot prop = new BitAnimator.RecordSlot();
+            prop.type = transformVariable.type;
+            prop.typeSet = BitAnimator.RecordSlot.PropertiesSet.Attribute;
+            prop.name = transformVariable.name;
+            prop.property = GetPropertyString(prop.type, transformVariable.propertyName);
+            prop.description = transformVariable.name;
+            prop.startFreq = 0;
+            prop.endFreq = 50;
+            prop.rangeMin = transformVariable.rangeMin;
+            prop.rangeMax = transformVariable.rangeMax;
+            prop.remap = new AnimationCurve(
+                new Keyframe(0, 0), new Keyframe(0.49999f, 0),
+                new Keyframe(0.50001f, 1), new Keyframe(1, 1)
+                );
+            prop.ampSmoothness = 0.2f;
+            prop.damping = 0f;
+            prop.channelMask = 0xFF;
+            prop.accumulate = false;
+            prop.loops = 1;
+            availableVariables.Add(prop);
+            menu.AddItem(new GUIContent(prop.description), false, AddProperty, prop);
+        }
+    }
+
+    public void UpdateBlendShapeProperties() 
 	{
 		SkinnedMeshRenderer skinMeshObj = renderer as SkinnedMeshRenderer;
         if (skinMeshObj == null)
@@ -585,7 +618,7 @@ public class BitAnimatorEditor : Editor
             EditorGUI.BeginChangeCheck();
             idQuality = EditorGUILayout.Popup(new GUIContent("Animation quality", "0.0 - Maximum compression\n0.5 - normal quality\n1.0 - lossless"), idQuality, options);
             if (EditorGUI.EndChangeCheck())
-                quality.floatValue = idQuality;
+                quality.floatValue = qualityVariants[Math.Max(Math.Min(qualityVariants.Length, idQuality), 0)];
             string[] displayedPresets = presets.Select(p => p.name).ToArray();
             int selectedPreset = Array.IndexOf(displayedPresets, presetName.stringValue);
             EditorGUI.BeginChangeCheck();
@@ -845,7 +878,7 @@ public class BitAnimatorEditor : Editor
 					EditorGUILayout.PropertyField (colors);
 					break;
 				case BitAnimator.RecordSlot.PropertyType.TexEnv:
-					EditorGUILayout.HelpBox("Textures haven't animation parameters", MessageType.Warning);
+					EditorGUILayout.HelpBox("Textures don't have animation parameters", MessageType.Warning);
 					break;
 				case BitAnimator.RecordSlot.PropertyType.Vector3:
 					minValue.vector4Value = EditorGUILayout.Vector3Field ("Min value", minValue.vector4Value);

--- a/Complex.cs
+++ b/Complex.cs
@@ -22,12 +22,12 @@ using System.Globalization;
 using System.Diagnostics.CodeAnalysis;
 using UnityEngine;
 
-namespace System.Numerics {
-
+namespace DSPLib
+{ 
 #if !SILVERLIGHT
     [Serializable]
 #endif // !SILVERLIGHT
-    public struct Complex : IEquatable<Complex>, IFormattable {
+    public struct ComplexFloat : IEquatable<ComplexFloat>, IFormattable {
 
         // --------------SECTION: Private Data members ----------- //
 
@@ -55,7 +55,7 @@ namespace System.Numerics {
 
         public float Magnitude {
             get {
-                return Complex.Abs(this);
+                return ComplexFloat.Abs(this);
             }
         }
 
@@ -67,68 +67,68 @@ namespace System.Numerics {
 
         // --------------SECTION: Attributes -------------- //
 
-        public static readonly Complex Zero = new Complex(0.0f, 0.0f);
-        public static readonly Complex One = new Complex(1.0f, 0.0f);
-        public static readonly Complex ImaginaryOne = new Complex(0.0f, 1.0f);
+        public static readonly ComplexFloat Zero = new ComplexFloat(0.0f, 0.0f);
+        public static readonly ComplexFloat One = new ComplexFloat(1.0f, 0.0f);
+        public static readonly ComplexFloat ImaginaryOne = new ComplexFloat(0.0f, 1.0f);
 
         // --------------SECTION: Constructors and factory methods -------------- //
 
-        public Complex(float real, float imaginary)  /* Constructor to create a complex number with rectangular co-ordinates  */
+        public ComplexFloat(float real, float imaginary)  /* Constructor to create a complex number with rectangular co-ordinates  */
         {
             this.m_real = real;
             this.m_imaginary = imaginary;
         }
 
-        public static Complex FromPolarCoordinates(float magnitude, float phase) /* Factory method to take polar inputs and create a Complex object */
+        public static ComplexFloat FromPolarCoordinates(float magnitude, float phase) /* Factory method to take polar inputs and create a Complex object */
         {
-            return new Complex((magnitude * Mathf.Cos(phase)), (magnitude * Mathf.Sin(phase)));
+            return new ComplexFloat((magnitude * Mathf.Cos(phase)), (magnitude * Mathf.Sin(phase)));
         }
 
-        public static Complex Negate(Complex value) {
+        public static ComplexFloat Negate(ComplexFloat value) {
             return -value;
         }
 
-        public static Complex Add(Complex left, Complex right) {
+        public static ComplexFloat Add(ComplexFloat left, ComplexFloat right) {
             return left + right;
         }
 
-        public static Complex Subtract(Complex left, Complex right) {
+        public static ComplexFloat Subtract(ComplexFloat left, ComplexFloat right) {
             return left - right;
         }
 
-        public static Complex Multiply(Complex left, Complex right) {
+        public static ComplexFloat Multiply(ComplexFloat left, ComplexFloat right) {
             return left * right;
         }
 
-        public static Complex Divide(Complex dividend, Complex divisor) {
+        public static ComplexFloat Divide(ComplexFloat dividend, ComplexFloat divisor) {
             return dividend / divisor;
         }
 
         // --------------SECTION: Arithmetic Operator(unary) Overloading -------------- //
-        public static Complex operator -(Complex value)  /* Unary negation of a complex number */
+        public static ComplexFloat operator -(ComplexFloat value)  /* Unary negation of a complex number */
         {
 
-            return (new Complex((-value.m_real), (-value.m_imaginary)));
+            return (new ComplexFloat((-value.m_real), (-value.m_imaginary)));
         }
 
         // --------------SECTION: Arithmetic Operator(binary) Overloading -------------- //       
-        public static Complex operator +(Complex left, Complex right) {
-            return (new Complex((left.m_real + right.m_real), (left.m_imaginary + right.m_imaginary)));
+        public static ComplexFloat operator +(ComplexFloat left, ComplexFloat right) {
+            return (new ComplexFloat((left.m_real + right.m_real), (left.m_imaginary + right.m_imaginary)));
 
         }
 
-        public static Complex operator -(Complex left, Complex right) {
-            return (new Complex((left.m_real - right.m_real), (left.m_imaginary - right.m_imaginary)));
+        public static ComplexFloat operator -(ComplexFloat left, ComplexFloat right) {
+            return (new ComplexFloat((left.m_real - right.m_real), (left.m_imaginary - right.m_imaginary)));
         }
 
-        public static Complex operator *(Complex left, Complex right) {
+        public static ComplexFloat operator *(ComplexFloat left, ComplexFloat right) {
             // Multiplication:  (a + bi)(c + di) = (ac -bd) + (bc + ad)i
             float result_Realpart = (left.m_real * right.m_real) - (left.m_imaginary * right.m_imaginary);
             float result_Imaginarypart = (left.m_imaginary * right.m_real) + (left.m_real * right.m_imaginary);
-            return (new Complex(result_Realpart, result_Imaginarypart));
+            return (new ComplexFloat(result_Realpart, result_Imaginarypart));
         }
 
-        public static Complex operator /(Complex left, Complex right) {
+        public static ComplexFloat operator /(ComplexFloat left, ComplexFloat right) {
             // Division : Smith's formula.
             float a = left.m_real;
             float b = left.m_imaginary;
@@ -137,17 +137,17 @@ namespace System.Numerics {
 
             if (Mathf.Abs(d) < Mathf.Abs(c)) {
                 float doc = d / c;
-                return new Complex((a + b * doc) / (c + d * doc), (b - a * doc) / (c + d * doc));
+                return new ComplexFloat((a + b * doc) / (c + d * doc), (b - a * doc) / (c + d * doc));
             } else {
                 float cod = c / d;
-                return new Complex((b + a * cod) / (d + c * cod), (-a + b * cod) / (d + c * cod));
+                return new ComplexFloat((b + a * cod) / (d + c * cod), (-a + b * cod) / (d + c * cod));
             }
         }
 
 
         // --------------SECTION: Other arithmetic operations  -------------- //
 
-        public static float Abs(Complex value) {
+        public static float Abs(ComplexFloat value) {
 
             if(float.IsInfinity(value.m_real) || float.IsInfinity(value.m_imaginary)) {
                 return float.PositiveInfinity;
@@ -171,29 +171,29 @@ namespace System.Numerics {
                 return d * Mathf.Sqrt(1.0f + r * r);
             }
         }
-        public static Complex Conjugate(Complex value) {
+        public static ComplexFloat Conjugate(ComplexFloat value) {
             // Conjugate of a Complex number: the conjugate of x+i*y is x-i*y 
 
-            return (new Complex(value.m_real, (-value.m_imaginary)));
+            return (new ComplexFloat(value.m_real, (-value.m_imaginary)));
 
         }
-        public static Complex Reciprocal(Complex value) {
+        public static ComplexFloat Reciprocal(ComplexFloat value) {
             // Reciprocal of a Complex number : the reciprocal of x+i*y is 1/(x+i*y)
             if ((value.m_real == 0) && (value.m_imaginary == 0)) {
-                return Complex.Zero;
+                return ComplexFloat.Zero;
             }
 
-            return Complex.One / value;
+            return ComplexFloat.One / value;
         }
 
         // --------------SECTION: Comparison Operator(binary) Overloading -------------- //
 
-        public static bool operator ==(Complex left, Complex right) {
+        public static bool operator ==(ComplexFloat left, ComplexFloat right) {
             return ((left.m_real == right.m_real) && (left.m_imaginary == right.m_imaginary));
 
 
         }
-        public static bool operator !=(Complex left, Complex right) {
+        public static bool operator !=(ComplexFloat left, ComplexFloat right) {
             return ((left.m_real != right.m_real) || (left.m_imaginary != right.m_imaginary));
 
         }
@@ -201,52 +201,52 @@ namespace System.Numerics {
         // --------------SECTION: Comparison operations (methods implementing IEquatable<ComplexNumber>,IComparable<ComplexNumber>) -------------- //
 
         public override bool Equals(object obj) {
-            if (!(obj is Complex)) return false;
-            return this == ((Complex)obj);
+            if (!(obj is ComplexFloat)) return false;
+            return this == ((ComplexFloat)obj);
         }
-        public bool Equals(Complex value) {
+        public bool Equals(ComplexFloat value) {
             return ((this.m_real.Equals(value.m_real)) && (this.m_imaginary.Equals(value.m_imaginary)));
 
         }
 
         // --------------SECTION: Type-casting basic numeric data-types to ComplexNumber  -------------- //
 
-        public static implicit operator Complex(Int16 value) {
-            return (new Complex(value, 0));
+        public static implicit operator ComplexFloat(Int16 value) {
+            return (new ComplexFloat(value, 0));
         }
-        public static implicit operator Complex(Int32 value) {
-            return (new Complex(value, 0));
+        public static implicit operator ComplexFloat(Int32 value) {
+            return (new ComplexFloat(value, 0));
         }
-        public static implicit operator Complex(Int64 value) {
-            return (new Complex(value, 0));
-        }
-        //[CLSCompliant(false)]
-        public static implicit operator Complex(UInt16 value) {
-            return (new Complex(value, 0));
+        public static implicit operator ComplexFloat(Int64 value) {
+            return (new ComplexFloat(value, 0));
         }
         //[CLSCompliant(false)]
-        public static implicit operator Complex(UInt32 value) {
-            return (new Complex(value, 0));
+        public static implicit operator ComplexFloat(UInt16 value) {
+            return (new ComplexFloat(value, 0));
         }
         //[CLSCompliant(false)]
-        public static implicit operator Complex(UInt64 value) {
-            return (new Complex(value, 0));
+        public static implicit operator ComplexFloat(UInt32 value) {
+            return (new ComplexFloat(value, 0));
         }
         //[CLSCompliant(false)]
-        public static implicit operator Complex(SByte value) {
-            return (new Complex(value, 0));
+        public static implicit operator ComplexFloat(UInt64 value) {
+            return (new ComplexFloat(value, 0));
         }
-        public static implicit operator Complex(Byte value) {
-            return (new Complex(value, 0));
+        //[CLSCompliant(false)]
+        public static implicit operator ComplexFloat(SByte value) {
+            return (new ComplexFloat(value, 0));
         }
-        public static implicit operator Complex(Single value) {
-            return (new Complex(value, 0));
+        public static implicit operator ComplexFloat(Byte value) {
+            return (new ComplexFloat(value, 0));
+        }
+        public static implicit operator ComplexFloat(Single value) {
+            return (new ComplexFloat(value, 0));
         }
         /*public static implicit operator Complex(double value) {
             return (new Complex(value, 0));
         }*/
-        public static explicit operator Complex(Decimal value) {
-            return (new Complex((float)value, 0));
+        public static explicit operator ComplexFloat(Decimal value) {
+            return (new ComplexFloat((float)value, 0));
         }
 
 
@@ -281,99 +281,99 @@ namespace System.Numerics {
 
         // --------------SECTION: Trigonometric operations (methods implementing ITrigonometric)  -------------- //
 
-        public static Complex Sin(Complex value) {
+        public static ComplexFloat Sin(ComplexFloat value) {
             float a = value.m_real;
             float b = value.m_imaginary;
-			return new Complex(Mathf.Sin(a) * HyperbolicMath.Cosh(b), Mathf.Cos(a) * HyperbolicMath.Sinh(b));
+			return new ComplexFloat(Mathf.Sin(a) * HyperbolicMath.Cosh(b), Mathf.Cos(a) * HyperbolicMath.Sinh(b));
         }
 
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Sinh", Justification = "Microsoft: Existing Name")]
-        public static Complex Sinh(Complex value) /* Hyperbolic sin */
+        public static ComplexFloat Sinh(ComplexFloat value) /* Hyperbolic sin */
         {
             float a = value.m_real;
             float b = value.m_imaginary;
-			return new Complex(HyperbolicMath.Sinh(a) * Mathf.Cos(b), HyperbolicMath.Cosh(a) * Mathf.Sin(b));
+			return new ComplexFloat(HyperbolicMath.Sinh(a) * Mathf.Cos(b), HyperbolicMath.Cosh(a) * Mathf.Sin(b));
 
         }
-        public static Complex Asin(Complex value) /* Arcsin */
+        public static ComplexFloat Asin(ComplexFloat value) /* Arcsin */
         {
             return (-ImaginaryOne) * Log(ImaginaryOne * value + Sqrt(One - value * value));
         }
 
-        public static Complex Cos(Complex value) {
+        public static ComplexFloat Cos(ComplexFloat value) {
             float a = value.m_real;
 			float b = value.m_imaginary;
-			return new Complex(Mathf.Cos(a) * HyperbolicMath.Cosh(b), - (Mathf.Sin(a) * HyperbolicMath.Sinh(b)));
+			return new ComplexFloat(Mathf.Cos(a) * HyperbolicMath.Cosh(b), - (Mathf.Sin(a) * HyperbolicMath.Sinh(b)));
         }
 
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Cosh", Justification = "Microsoft: Existing Name")]
-        public static Complex Cosh(Complex value) /* Hyperbolic cos */
+        public static ComplexFloat Cosh(ComplexFloat value) /* Hyperbolic cos */
         {
             float a = value.m_real;
             float b = value.m_imaginary;
-			return new Complex(HyperbolicMath.Cosh(a) * Mathf.Cos(b), HyperbolicMath.Sinh(a) * Mathf.Sin(b));
+			return new ComplexFloat(HyperbolicMath.Cosh(a) * Mathf.Cos(b), HyperbolicMath.Sinh(a) * Mathf.Sin(b));
         }
-        public static Complex Acos(Complex value) /* Arccos */
+        public static ComplexFloat Acos(ComplexFloat value) /* Arccos */
         {
             return (-ImaginaryOne) * Log(value + ImaginaryOne*Sqrt(One - (value * value)));
 
         }
-        public static Complex Tan(Complex value) {
+        public static ComplexFloat Tan(ComplexFloat value) {
             return (Sin(value) / Cos(value));
         }
 
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Tanh", Justification = "Microsoft: Existing Name")]
-        public static Complex Tanh(Complex value) /* Hyperbolic tan */
+        public static ComplexFloat Tanh(ComplexFloat value) /* Hyperbolic tan */
         {
             return (Sinh(value) / Cosh(value));
         }
-        public static Complex Atan(Complex value) /* Arctan */
+        public static ComplexFloat Atan(ComplexFloat value) /* Arctan */
         {
-            Complex Two = new Complex(2.0f, 0.0f);
+            ComplexFloat Two = new ComplexFloat(2.0f, 0.0f);
             return (ImaginaryOne / Two) * (Log(One - ImaginaryOne * value) - Log(One + ImaginaryOne * value));
         }
 
         // --------------SECTION: Other numerical functions  -------------- //        
 
-        public static Complex Log(Complex value) /* Log of the complex number value to the base of 'e' */
+        public static ComplexFloat Log(ComplexFloat value) /* Log of the complex number value to the base of 'e' */
         {
-            return (new Complex((Mathf.Log(Abs(value))), (Mathf.Atan2(value.m_imaginary, value.m_real))));
+            return (new ComplexFloat((Mathf.Log(Abs(value))), (Mathf.Atan2(value.m_imaginary, value.m_real))));
 
         }
-        public static Complex Log(Complex value, float baseValue) /* Log of the complex number to a the base of a float */
+        public static ComplexFloat Log(ComplexFloat value, float baseValue) /* Log of the complex number to a the base of a float */
         {
             return (Log(value) / Log(baseValue));
         }
-        public static Complex Log10(Complex value) /* Log to the base of 10 of the complex number */
+        public static ComplexFloat Log10(ComplexFloat value) /* Log to the base of 10 of the complex number */
         {
 
-            Complex temp_log = Log(value);
+            ComplexFloat temp_log = Log(value);
             return (Scale(temp_log, (float)LOG_10_INV));
 
         }
-        public static Complex Exp(Complex value) /* The complex number raised to e */
+        public static ComplexFloat Exp(ComplexFloat value) /* The complex number raised to e */
         {
             float temp_factor = Mathf.Exp(value.m_real);
             float result_re = temp_factor * Mathf.Cos(value.m_imaginary);
             float result_im = temp_factor * Mathf.Sin(value.m_imaginary);
-            return (new Complex(result_re, result_im));
+            return (new ComplexFloat(result_re, result_im));
         }
 
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Sqrt", Justification = "Microsoft: Existing Name")]
-        public static Complex Sqrt(Complex value) /* Square root ot the complex number */
+        public static ComplexFloat Sqrt(ComplexFloat value) /* Square root ot the complex number */
         {
-            return Complex.FromPolarCoordinates(Mathf.Sqrt(value.Magnitude), value.Phase / 2.0f);
+            return ComplexFloat.FromPolarCoordinates(Mathf.Sqrt(value.Magnitude), value.Phase / 2.0f);
         }
 
-        public static Complex Pow(Complex value, Complex power) /* A complex number raised to another complex number */
+        public static ComplexFloat Pow(ComplexFloat value, ComplexFloat power) /* A complex number raised to another complex number */
         {
 
-            if (power == Complex.Zero) {
-                return Complex.One;
+            if (power == ComplexFloat.Zero) {
+                return ComplexFloat.One;
             }
 
-            if (value == Complex.Zero) {
-                return Complex.Zero;
+            if (value == ComplexFloat.Zero) {
+                return ComplexFloat.Zero;
             }
 
             float a = value.m_real;
@@ -381,29 +381,29 @@ namespace System.Numerics {
             float c = power.m_real;
             float d = power.m_imaginary;
 
-            float rho = Complex.Abs(value);
+            float rho = ComplexFloat.Abs(value);
             float theta = Mathf.Atan2(b, a);
             float newRho = c * theta + d * Mathf.Log(rho);
 
 			float t = Mathf.Pow(rho, c) * Mathf.Pow((float)Math.E, -d * theta);
 
-            return new Complex(t * Mathf.Cos(newRho), t * Mathf.Sin(newRho));
+            return new ComplexFloat(t * Mathf.Cos(newRho), t * Mathf.Sin(newRho));
         }
 
-        public static Complex Pow(Complex value, float power) // A complex number raised to a real number 
+        public static ComplexFloat Pow(ComplexFloat value, float power) // A complex number raised to a real number 
         {
-            return Pow(value, new Complex(power, 0));
+            return Pow(value, new ComplexFloat(power, 0));
         }
 
 
 
         //--------------- SECTION: Private member functions for internal use -----------------------------------//
 
-        private static Complex Scale(Complex value, float factor) {
+        private static ComplexFloat Scale(ComplexFloat value, float factor) {
 
             float result_re = factor * value.m_real;
             float result_im = factor * value.m_imaginary;
-            return (new Complex(result_re, result_im));
+            return (new ComplexFloat(result_re, result_im));
         }
 
     }

--- a/ComputeProgram.cs
+++ b/ComputeProgram.cs
@@ -1399,7 +1399,7 @@ namespace AudioVisualization
                 keyframes = null;
                 return;
             }
-            keyframes = new ComputeBuffer(curve.length, 20);
+            keyframes = new ComputeBuffer(curve.length, 32);
             keyframes.SetData(curve.keys);
         }
         public void ApplyRemap(ComputeBuffer input, ComputeBuffer output, int count, ComputeBuffer remap)

--- a/ComputeProgram.cs
+++ b/ComputeProgram.cs
@@ -1462,7 +1462,7 @@ namespace AudioVisualization
             keys[2].value = 1;
             keys[3].time = fadeOut;
             keys[3].value = 0;
-            InitializeBuffer(ref keyframes, keys.Length, 20);
+            InitializeBuffer(ref keyframes, keys.Length, 32);
             keyframes.SetData(keys);
             computeShader.SetBuffer(CurveFilter.ID, cs_Output, input);
             computeShader.SetBuffer(CurveFilter.ID, cs_Keyframes, keyframes);

--- a/DSPLib.cs
+++ b/DSPLib.cs
@@ -143,7 +143,7 @@ namespace DSPLib
         /// </summary>
         /// <param name="timeSeries"></param>
         /// <returns>Complex[] FFT Result</returns>
-        public Complex[] Execute(float[] timeSeries)
+        public ComplexFloat[] Execute(float[] timeSeries)
         {
 			UnityEngine.Debug.Assert(timeSeries.Length <= mLengthTotal, "The input timeSeries length was greater than the total number of points that was initialized. DFT.Exectue()");
 
@@ -151,7 +151,7 @@ namespace DSPLib
             float[] totalInputData = new float[mLengthTotal];
             Array.Copy(timeSeries, totalInputData, timeSeries.Length);
 
-            Complex[] output;
+            ComplexFloat[] output;
             if (mOutOfMemory)
                 output = Dft(totalInputData);
             else
@@ -167,13 +167,13 @@ namespace DSPLib
         /// </summary>
         /// <param name="timeSeries"></param>
         /// <returns>Complex[] result</returns>
-        private Complex[] Dft(float[] timeSeries)
+        private ComplexFloat[] Dft(float[] timeSeries)
         {
             UInt32 n = mLengthTotal;
             UInt32 m = mLengthHalf;
             float[] re = new float[m];
             float[] im = new float[m];
-            Complex[] result = new Complex[m];
+            ComplexFloat[] result = new ComplexFloat[m];
             float sf = 2.0f * Mathf.PI / n;
 
             //Parallel.For(0, m, (j) =>
@@ -186,12 +186,12 @@ namespace DSPLib
                     im[j] -= timeSeries[k] * Mathf.Sin(a * k) * mDFTScale;
                 }
 
-                result[j] = new Complex(re[j], im[j]);
+                result[j] = new ComplexFloat(re[j], im[j]);
             }
 
             // DC and Fs/2 Points are scaled differently, since they have only a real part
-            result[0] = new Complex(result[0].Real / Mathf.Sqrt(2.0f), 0.0f);
-            result[mLengthHalf - 1] = new Complex(result[mLengthHalf - 1].Real / Mathf.Sqrt(2.0f), 0.0f);
+            result[0] = new ComplexFloat(result[0].Real / Mathf.Sqrt(2.0f), 0.0f);
+            result[mLengthHalf - 1] = new ComplexFloat(result[mLengthHalf - 1].Real / Mathf.Sqrt(2.0f), 0.0f);
 
             return result;
         }
@@ -203,13 +203,13 @@ namespace DSPLib
         /// </summary>
         /// <param name="timeSeries"></param>
         /// <returns>Complex[] result</returns>
-        private Complex[] DftCached(float[] timeSeries)
+        private ComplexFloat[] DftCached(float[] timeSeries)
         {
             UInt32 n = mLengthTotal;
             UInt32 m = mLengthHalf;
             float[] re = new float[m];
             float[] im = new float[m];
-            Complex[] result = new Complex[m];
+            ComplexFloat[] result = new ComplexFloat[m];
 
             //Parallel.For(0, m, (j) =>
             for (UInt32 j = 0; j < m; j++)
@@ -219,12 +219,12 @@ namespace DSPLib
                     re[j] += timeSeries[k] * mCosTerm[j, k];
                     im[j] -= timeSeries[k] * mSinTerm[j, k];
                 }
-                result[j] = new Complex(re[j], im[j]);
+                result[j] = new ComplexFloat(re[j], im[j]);
             }
 
             // DC and Fs/2 Points are scaled differently, since they have only a real part
-            result[0] = new Complex(result[0].Real / Mathf.Sqrt(2.0f), 0.0f);
-            result[mLengthHalf - 1] = new Complex(result[mLengthHalf - 1].Real / Mathf.Sqrt(2.0f), 0.0f);
+            result[0] = new ComplexFloat(result[0].Real / Mathf.Sqrt(2.0f), 0.0f);
+            result[mLengthHalf - 1] = new ComplexFloat(result[mLengthHalf - 1].Real / Mathf.Sqrt(2.0f), 0.0f);
 
             return result;
         }
@@ -382,7 +382,7 @@ namespace DSPLib
         /// </summary>
         /// <param name="timeSeries"></param>
         /// <returns>Complex[] Spectrum</returns>
-        public Complex[] Execute(float[] timeSeries)
+        public ComplexFloat[] Execute(float[] timeSeries)
         {
             UInt32 numFlies = mLengthTotal >> 1;  // Number of butterflies per sub-FFT
             UInt32 span = mLengthTotal >> 1;      // Width of the butterfly
@@ -479,22 +479,22 @@ namespace DSPLib
             // linked list elements to a complex output vector & properly apply scale factors.
 
             x = mX[0];
-            Complex[] unswizzle = new Complex[mLengthTotal];
+            ComplexFloat[] unswizzle = new ComplexFloat[mLengthTotal];
             while (x != null)
             {
                 UInt32 target = x.revTgt;
-                unswizzle[target] = new Complex(x.re * mFFTScale, x.im * mFFTScale);
+                unswizzle[target] = new ComplexFloat(x.re * mFFTScale, x.im * mFFTScale);
                 x = x.next;
             }
 
             // Return 1/2 the FFT result from DC to Fs/2 (The real part of the spectrum)
             //UInt32 halfLength = ((mN + mZp) / 2) + 1;
-            Complex[] result = new Complex[mLengthHalf];
+            ComplexFloat[] result = new ComplexFloat[mLengthHalf];
             Array.Copy(unswizzle, result, mLengthHalf);
 
             // DC and Fs/2 Points are scaled differently, since they have only a real part
-            result[0] = new Complex(result[0].Real / Mathf.Sqrt(2), 0.0f);
-            result[mLengthHalf - 1] = new Complex(result[mLengthHalf - 1].Real / Mathf.Sqrt(2), 0.0f);
+            result[0] = new ComplexFloat(result[0].Real / Mathf.Sqrt(2), 0.0f);
+            result[mLengthHalf - 1] = new ComplexFloat(result[mLengthHalf - 1].Real / Mathf.Sqrt(2), 0.0f);
 
             return result;
         }
@@ -1266,7 +1266,7 @@ namespace DSPLib
             /// </summary>
             /// <param name="rawFFT"></param>
             /// <returns>float[] MagSquared Format</returns>
-            public static float[] ToMagnitudeSquared(Complex[] rawFFT)
+            public static float[] ToMagnitudeSquared(ComplexFloat[] rawFFT)
             {
                 UInt32 np = (UInt32)rawFFT.Length;
                 float[] magSquared = new float[np];
@@ -1285,7 +1285,7 @@ namespace DSPLib
             /// </summary>
             /// <param name="rawFFT"></param>
             /// <returns>float[] Magnitude Format (Vrms)</returns>
-            public static float[] ToMagnitude(Complex[] rawFFT)
+            public static float[] ToMagnitude(ComplexFloat[] rawFFT)
             {
                 UInt32 np = (UInt32)rawFFT.Length;
                 float[] mag = new float[np];
@@ -1303,7 +1303,7 @@ namespace DSPLib
             /// </summary>
             /// <param name="rawFFT"> Complex[] input array"></param>
             /// <returns>float[] Magnitude Format (dBV)</returns>
-            public static float[] ToMagnitudeDBV(Complex[] rawFFT)
+            public static float[] ToMagnitudeDBV(ComplexFloat[] rawFFT)
             {
                 UInt32 np = (UInt32)rawFFT.Length;
                 float[] mag = new float[np];
@@ -1326,7 +1326,7 @@ namespace DSPLib
             /// </summary>
             /// <param name="rawFFT"> Complex[] input array"></param>
             /// <returns>float[] Phase (Degrees)</returns>
-            public static float[] ToPhaseDegrees(Complex[] rawFFT)
+            public static float[] ToPhaseDegrees(ComplexFloat[] rawFFT)
             {
                 float sf = 180.0f / Mathf.PI; // Degrees per Radian scale factor
 
@@ -1346,7 +1346,7 @@ namespace DSPLib
             /// </summary>
             /// <param name="rawFFT"> Complex[] input array"></param>
             /// <returns>float[] Phase (Degrees)</returns>
-            public static float[] ToPhaseRadians(Complex[] rawFFT)
+            public static float[] ToPhaseRadians(ComplexFloat[] rawFFT)
             {
                 UInt32 np = (UInt32)rawFFT.Length;
                 float[] phase = new float[np];

--- a/Example/Shaders.meta
+++ b/Example/Shaders.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 75c0b2df36028754782f478bbdcb9b7a
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,33 @@
 # BitAnimator 
-Version: 1.0 preview (build 2019.07.16)
+Version: 1.0.2 preview (build 2020.07.18)
+
+
+Unity editor extension for music visualization and animation recording
+
+Changes in version 1.0:
+---
+* Testing animations in Play and Edit Mode
+* Parameter for property: Damping - creates a smooth fading animation
+* Parameter for property: Smoothness - completely smooths the animation making it less sharp
+* Parameter for property: Accumulate - the animation does not subside and constantly accumulates
+* Parameter for property: Lerp repeats - loop the animation when it reaches its maximum (useful with Accumulate)
+* Modifiers for property: TimeRange - limits the recording of the animation effect by time (has 4 values: start of rise, start, end, smooth end)
+* Added ability to compress animation file (Advanced settings / Animation quality)
+* Updated GUI for BitAnimator
+* Added the ability to switch the interface mode from simple to expert
+* GUI for Window / BitAnimator allows you to test frequencies and peaks in music in test mode
+* Calculations on the GPU (now animations can be rewritten up to 100 times faster)
+* Added new filters: Exp, Hann Poison, Dolph Chebyshev
+
+In development:
+---
+* GUI Window / BitAnimator
+* Demo scenes - usage examples and templates
+* Presets
+* Modifiers for property
+* Beat detector
+* Beat Per Minute Analysis (BPM)
+----
 
 расширение редактора Unity для визуализации музыки и записи в анимацию
 

--- a/Shaders/BitAnimatorKernels.compute
+++ b/Shaders/BitAnimatorKernels.compute
@@ -78,6 +78,8 @@ struct Keyframe
 	float inTangent;
 	float outTangent;
 	int tangentMode;
+	float unused0;
+	double unused1;
 };
 Buffer<float> Window;
 Buffer<float> Input;
@@ -1215,6 +1217,8 @@ void FillKeyframes(uint3 id : SV_DispatchThreadID)
 		k.inTangent = 0.0;
 		k.outTangent = 0.0;
 		k.tangentMode = 0;
+		k.unused0 = 0;
+		k.unused1 = 0;
 		OutputKeyframes[id.x] = k;
 	}
 }
@@ -1331,6 +1335,8 @@ void KeyframesCreator(uint3 id : SV_DispatchThreadID, uint localID : SV_GroupInd
 			result.inTangent = 0;
 			result.outTangent = 0;
 			result.tangentMode = 1; //Broken (inTangent != outTangent)
+			result.unused0 = 0;
+			result.unused1 = 0;
 			OutputKeyframes[id.x + channel * GridSize.x] = result;
 		}
 	}
@@ -1371,6 +1377,8 @@ void RemapGradientKernel(uint3 id : SV_DispatchThreadID, uint localID : SV_Group
 			result.inTangent = 0;
 			result.outTangent = 0;
 			result.tangentMode = 1; //Broken (inTangent != outTangent)
+			result.unused0 = 0;
+			result.unused1 = 0;
 			OutputKeyframes[id.x + channel * GridSize.x] = result;
 		}
 	}


### PR DESCRIPTION
This has a few basic fixes that seems to make it work again with Unity 2018, and therefore be used for making VRChat animations again.

Most of it was just naming conflict resolution, but I did change the compute stride to be 32 - it would otherwise throw exceptions about not being a multiple of the base c# stride width (which is 32 bytes)